### PR TITLE
Adds unique ID to notifications to prevent multiple instances

### DIFF
--- a/addon/components/ember-notify.js
+++ b/addon/components/ember-notify.js
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
         break;
       case 'uikit':
           theme = UIkitTheme.create();
-          break;  
+          break;
       case 'foundation-5':
         theme = Foundation5Theme.create();
         break;
@@ -54,6 +54,10 @@ export default Ember.Component.extend({
   },
   show: function(message) {
     if (this.get('isDestroyed')) return;
+    const uid = Ember.get(message, 'uid');
+    if (uid && this.get('messages').findBy('uid', uid)) {
+      return;
+    }
     if (!(message instanceof Message)) {
       message = Message.create(message);
     }


### PR DESCRIPTION
Adding a uid to a message ensures the notification will not open another instance whilst one is already open.

For example, the following code will ensure duplicates of the cookie policy notification will be prevented from opening at the same time, should the code be triggered again.

```javascript
get(this, 'notify')
  .alert({
    uid: 'cookie-policy',
    closeAfter: null,
    partial: 'notifications/cookie-policy'
  });
```

This can be particularly useful for using Ember Notify as an unobtrusive modal confirmation, where users may require to interact with the notification, but also are able to trigger the same notification multiple times.