### PR TITLE
Add call to message.didRemove when removing message

### DIFF
--- a/addon/components/ember-notify/message.js
+++ b/addon/components/ember-notify/message.js
@@ -74,6 +74,9 @@ export default Ember.Component.extend({
         remove();
       }
       function remove() {
+        if (this.get('message.didRemove')) {
+          this.get('message.didRemove')()
+        }
         var parentView = this.get('parentView');
         if (this.get('isDestroyed') || !parentView || !parentView.get('messages')) return;
         parentView.get('messages').removeObject(this.get('message'));


### PR DESCRIPTION
I need to receive a callback when the notification is removed from display, either when it times out or if the user submits it.

I'm not sure if it's the best way to go about it, but I've made a small change to call message.didRemove when removing the message. This can then be configured in the message like this

```      
let message = this.get('notify').info(messageText);
set(message,'didRemove', () => { this.goingToRemove() });
```

Could you consider merging this change, or suggesting an alternative approach?

Thanks!