### PR TITLE
doc turning off css import in ember-cli-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ The following snippet summarizes rules needed for a custom look. For a complete 
 .custom-notify .ember-notify-hide {}
 ```
 
+### Turn off loading CSS
+
+If you want to use the addon without loading the CSS themes (because you have your own CSS) add this to 
+your `ember-cli-build.js` file:
+
+```
+var app = new EmberApp({
+  emberNotify: {
+    importCss: false
+  }
+});
+```
+
 ### Usage in Tests
 
 The scheduler that shows and hides the messages is disabled by default when Ember is running tests


### PR DESCRIPTION
I dug this up from https://github.com/aexmachina/ember-notify/issues/29
It's a feature worth documenting. As a new user I was looking for this specifically, because I've been given a prototype with css but no logic, and it looks like this tackles the hard parts (like turning off for tests).