### PR TITLE
 Add `close` method for manually closing message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+### BREAKING CHANGES
+  - Messages can be programmatically closed by doing `message.close()`. Changing the `visible` property was broken.
+
 ## v6.0
  - Don't require jquery #119
  - Document `importCss` #124

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ let message = this.notify.alert('You can control how long it is displayed', {
 ...and you can hide messages programmatically:
 
 ```js
-message.set('visible', false);
+message.close();
 ```
 
 You can specify raw HTML:

--- a/addon/components/ember-notify/message.js
+++ b/addon/components/ember-notify/message.js
@@ -28,6 +28,7 @@ export default Component.extend({
       // Should really be in didInsertElement but Glimmer doesn't allow this
       this.set('message.visible', true);
     }
+    this.set('message.container', this);
   },
 
   didInsertElement() {

--- a/addon/message.js
+++ b/addon/message.js
@@ -8,5 +8,14 @@ export default EmberObject.extend({
   type: 'info',
   closeAfter: undefined,
   visible: undefined,
-  classNames: EMPTY_ARRAY
+  classNames: EMPTY_ARRAY,
+
+  // will be set to the component rendering this message
+  container: undefined,
+
+  close() {
+    if (this.container) {
+      this.container.selfClose();
+    }
+  }
 });

--- a/tests/unit/components/ember-notify-test.js
+++ b/tests/unit/components/ember-notify-test.js
@@ -137,9 +137,7 @@ describe('EmberNotifyComponent', function() {
     let start = new Date();
     let component = this.subject();
     let message = component.show({
-      text: 'Hello world',
-      closeAfter: 500,
-      removeAfter: 100
+      text: 'Hello world'
     });
 
     this.render();

--- a/tests/unit/components/ember-notify-test.js
+++ b/tests/unit/components/ember-notify-test.js
@@ -144,7 +144,7 @@ describe('EmberNotifyComponent', function() {
 
     let notify = find('.ember-notify');
     expect(notify).to.exist;
-    run(() => message.set('visible', false) );
+    run(() => message.close() );
     observeSequence(message, 'visible', [null])
       .then(observed => next(() => {
         expect(find('.ember-notify')).to.not.exist;


### PR DESCRIPTION
Using the `visible` property was broken (#138). Therefore I added a new method to bring back the functionality.