### PR TITLE
Fix TypeError: _string.isHTMLSafe is not a function

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,5 +1,5 @@
 import { computed } from '@ember/object';
-import { isHTMLSafe } from '@ember/string';
+import { isHTMLSafe } from '@ember/template';
 import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import Message from './message';


### PR DESCRIPTION
Update ember/string with ember/template import of isHTMLsafe

It is related to this deprecation https://deprecations.emberjs.com/v3.x#toc_ember-string-htmlsafe-ishtmlsafe

The thing is, my app is using Ember 3.27 and I had an error from above using notify addon. I changed import and used my fork version from GH since then, all good. I assume it maybe false change, because it should work fine until Ember 4.0.

Meanwhile we can wait for 4.0 release and merge it after. 
The  `@ember/template` import is available since 3.8 release https://api.emberjs.com/ember/3.8/modules/@ember%2Ftemplate