### PR TITLE
Fix deprecation in Ember 3.27+, import error in Ember 4.x

### DIFF
--- a/addon/components/ember-notify.js
+++ b/addon/components/ember-notify.js
@@ -1,5 +1,6 @@
 import { A } from '@ember/array';
 import { computed } from '@ember/object';
+import { oneWay } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import layout from '../templates/components/ember-notify';
@@ -17,7 +18,7 @@ export default Component.extend({
   closeAfter: 2500,
   messages: null,
 
-  source: computed.oneWay('notify'),
+  source: oneWay('notify'),
 
   classPrefix: computed('defaultClass', function() {
     return this.defaultClass || 'ember-notify-default';


### PR DESCRIPTION
In Ember 3.27+, accessing `oneWay` off of `computed` will throw a deprecation warning, which turns into a hard error in Ember 4.x (currently `ember-beta`). Instead, we can fix it to directly import `oneWay` from the `@ember/object/computed` module