### PR TITLE
Replace Ember assign with Object.assign

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,5 @@
 import { computed } from '@ember/object';
 import { isHTMLSafe } from '@ember/template';
-import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import Message from './message';
 
@@ -33,7 +32,7 @@ let Notify = Service.extend({
       text = null;
     }
 
-    let message = Message.create(assign({
+    let message = Message.create(Object.assign({
       text: text,
       type: type
     }, options));


### PR DESCRIPTION
Fixes the Ember.assign deprecation: https://deprecations.emberjs.com/v4.x/#toc_ember-polyfills-deprecate-assign

This was finally dropped from Ember canary and is breaking tests in consuming projects that test against the canary scenario.